### PR TITLE
Couple of cleanups

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,18 @@
 {
     "dotnet-test-explorer.testProjectPath": "**/*UnitTests.csproj",
-    "dotnet.defaultSolution": "BasicCompilerLogger.sln"
+    "dotnet.defaultSolution": "BasicCompilerLogger.sln",
+    "cSpell.words": [
+        "binlog",
+        "cacheable",
+        "classlib",
+        "classlibmulti",
+        "complog",
+        "Complogs",
+        "cryptodir",
+        "jaredpar",
+        "msbuild",
+        "Mvid",
+        "Relogger",
+        "Xunit"
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "dotnet-test-explorer.testProjectPath": "**/*UnitTests.csproj",
     "dotnet.defaultSolution": "BasicCompilerLogger.sln",
     "cSpell.words": [
+        "appconfig",
         "binlog",
         "cacheable",
         "classlib",
@@ -9,10 +10,12 @@
         "complog",
         "Complogs",
         "cryptodir",
+        "cryptokeyfile",
         "jaredpar",
         "msbuild",
         "Mvid",
         "Relogger",
+        "ruleset",
         "Xunit"
     ]
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <LangVersion>11.0</LangVersion>
     <DebugType>embedded</DebugType>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 </Project>

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -28,7 +28,7 @@ public sealed class CompilerLogReaderTests : TestBase
     [Theory]
     [InlineData("console")]
     [InlineData("classlib")]
-    public void ReadDifferntTemplates(string template)
+    public void ReadDifferentTemplates(string template)
     {
         RunDotNet($"new {template} --name example --output .");
         RunDotNet("build -bl");
@@ -184,7 +184,7 @@ public sealed class CompilerLogReaderTests : TestBase
     public void ProjectSingleTarget()
     {
         using var reader = CompilerLogReader.Create(Fixture.ClassLibComplogPath);
-        var list = reader.ReadCompilationDatas();
+        var list = reader.ReadAllCompilationData();
         Assert.Single(list);
         Assert.NotNull(list.Single(x => x.CompilerCall.TargetFramework == "net7.0"));
     }
@@ -193,7 +193,7 @@ public sealed class CompilerLogReaderTests : TestBase
     public void ProjectMultiTarget()
     {
         using var reader = CompilerLogReader.Create(Fixture.ClassLibMultiComplogPath);
-        var list = reader.ReadCompilationDatas();
+        var list = reader.ReadAllCompilationData();
         Assert.Equal(2, list.Count);
         Assert.NotNull(list.Single(x => x.CompilerCall.TargetFramework == "net6.0"));
         Assert.NotNull(list.Single(x => x.CompilerCall.TargetFramework == "net7.0"));

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -179,4 +179,23 @@ public sealed class CompilerLogReaderTests : TestBase
         Assert.True(analyzers1.IsDisposed);
         Assert.True(analyzers2.IsDisposed);
     }
+
+    [Fact]
+    public void ProjectSingleTarget()
+    {
+        using var reader = CompilerLogReader.Create(Fixture.ClassLibComplogPath);
+        var list = reader.ReadCompilationDatas();
+        Assert.Single(list);
+        Assert.NotNull(list.Single(x => x.CompilerCall.TargetFramework == "net7.0"));
+    }
+
+    [Fact]
+    public void ProjectMultiTarget()
+    {
+        using var reader = CompilerLogReader.Create(Fixture.ClassLibMultiComplogPath);
+        var list = reader.ReadCompilationDatas();
+        Assert.Equal(2, list.Count);
+        Assert.NotNull(list.Single(x => x.CompilerCall.TargetFramework == "net6.0"));
+        Assert.NotNull(list.Single(x => x.CompilerCall.TargetFramework == "net7.0"));
+    }
 }

--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -43,7 +43,7 @@ public sealed class ExportUtilTests : TestBase
         var sdkDirs = DotnetUtil.GetSdkDirectories();
         var exportUtil = new ExportUtil(reader);
         var count = 0;
-        foreach (var compilerCall in reader.ReadCompilerCalls())
+        foreach (var compilerCall in reader.ReadAllCompilerCalls())
         {
             count++;
             TestOutputHelper.WriteLine($"Testing export for {compilerCall.ProjectFileName} - {compilerCall.TargetFramework}");

--- a/src/Basic.CompilerLog.Util/BasicAnalyzers.cs
+++ b/src/Basic.CompilerLog.Util/BasicAnalyzers.cs
@@ -23,7 +23,7 @@ public readonly struct BasicAnalyzersOptions
     /// When true requests for the exact same set of analyzers will return 
     /// the same <see cref="BasicAnalyzers"/> instance.
     /// </summary>
-    public bool Cachable { get; }
+    public bool Cacheable { get; }
 
     public BasicAnalyzersOptions(
         BasicAnalyzersKind kind,
@@ -32,7 +32,7 @@ public readonly struct BasicAnalyzersOptions
     {
         Kind = kind;
         CompilerLoadContext = CommonUtil.GetAssemblyLoadContext(compilerLoadContext);
-        Cachable = cacheable;
+        Cacheable = cacheable;
     }
 }
 

--- a/src/Basic.CompilerLog.Util/BinaryLogUtil.cs
+++ b/src/Basic.CompilerLog.Util/BinaryLogUtil.cs
@@ -40,7 +40,7 @@ public static class BinaryLogUtil
         public override string ToString() => $"{Path.GetFileName(ProjectFile)}({TargetFramework})";
     }
 
-    public static List<CompilerCall> ReadCompilerCalls(Stream stream, List<string> diagnosticList, Func<CompilerCall, bool>? predicate = null)
+    public static List<CompilerCall> ReadAllCompilerCalls(Stream stream, List<string> diagnosticList, Func<CompilerCall, bool>? predicate = null)
     {
         predicate ??= static _ => true;
         var list = new List<CompilerCall>();

--- a/src/Basic.CompilerLog.Util/CompilerLogUtil.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogUtil.cs
@@ -32,7 +32,7 @@ public static class CompilerLogUtil
     {
         using var compilerLogStream = new FileStream(compilerLogFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
         using var binaryLogStream = new FileStream(binaryLogFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-        return ConvertBinaryLog(binaryLogStream, compilerLogStream);
+        return ConvertBinaryLog(binaryLogStream, compilerLogStream, predicate);
     }
 
     public static List<string> ConvertBinaryLog(Stream binaryLogStream, Stream compilerLogStream, Func<CompilerCall, bool>? predicate = null)
@@ -49,7 +49,7 @@ public static class CompilerLogUtil
     public static bool TryConvertBinaryLog(Stream binaryLogStream, Stream compilerLogStream, List<string> diagnostics, Func<CompilerCall, bool>? predicate = null)
     {
         predicate ??= static _ => true;
-        var list = BinaryLogUtil.ReadCompilerCalls(binaryLogStream, diagnostics);
+        var list = BinaryLogUtil.ReadAllCompilerCalls(binaryLogStream, diagnostics);
         using var builder = new CompilerLogBuilder(compilerLogStream, diagnostics);
         var success = true;
         foreach (var compilerInvocation in list)
@@ -65,28 +65,28 @@ public static class CompilerLogUtil
         return success;
     }
 
-    public static List<CompilerCall> ReadCompilerCalls(string compilerLogFilePath, Func<CompilerCall, bool>? predicate = null)
+    public static List<CompilerCall> ReadAllCompilerCalls(string compilerLogFilePath, Func<CompilerCall, bool>? predicate = null)
     {
         using var compilerLogStream = new FileStream(compilerLogFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-        return ReadCompilerCalls(compilerLogStream, predicate);
+        return ReadAllCompilerCalls(compilerLogStream, predicate);
     }
 
-    public static List<CompilerCall> ReadCompilerCalls(Stream compilerLogStream, Func<CompilerCall, bool>? predicate = null)
+    public static List<CompilerCall> ReadAllCompilerCalls(Stream compilerLogStream, Func<CompilerCall, bool>? predicate = null)
     {
         using var reader = CompilerLogReader.Create(compilerLogStream);
-        return reader.ReadCompilerCalls(predicate);
+        return reader.ReadAllCompilerCalls(predicate);
     }
 
-    public static List<CompilationData> ReadCompilationDatas(string compilerLogFilePath, Func<CompilerCall, bool>? predicate = null)
+    public static List<CompilationData> ReadAllCompilationData(string compilerLogFilePath, Func<CompilerCall, bool>? predicate = null)
     {
         using var compilerLogStream = new FileStream(compilerLogFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-        return ReadCompilationDatas(compilerLogStream, predicate);
+        return ReadAllCompilationData(compilerLogStream, predicate);
     }
 
-    public static List<CompilationData> ReadCompilationDatas(Stream compilerLogStream, Func<CompilerCall, bool>? predicate = null)
+    public static List<CompilationData> ReadAllCompilationData(Stream compilerLogStream, Func<CompilerCall, bool>? predicate = null)
     {
         using var reader = CompilerLogReader.Create(compilerLogStream);
-        return reader.ReadCompilationDatas(predicate);
+        return reader.ReadAllCompilationData(predicate);
     }
 
     private static Exception CreateException(string message, IEnumerable<string> diagnostics)

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -121,7 +121,7 @@ int RunAnalyzers(IEnumerable<string> args)
 
         using var compilerLogStream = GetOrCreateCompilerLogStream(extra);
         using var reader = CompilerLogReader.Create(compilerLogStream, leaveOpen: true);
-        var compilerCalls = reader.ReadCompilerCalls(options.FilterCompilerCalls);
+        var compilerCalls = reader.ReadAllCompilerCalls(options.FilterCompilerCalls);
 
         foreach (var compilerCall in compilerCalls)
         {
@@ -162,7 +162,7 @@ int RunPrint(IEnumerable<string> args)
         }
 
         using var compilerLogStream = GetOrCreateCompilerLogStream(extra);
-        var compilerCalls = CompilerLogUtil.ReadCompilerCalls(
+        var compilerCalls = CompilerLogUtil.ReadAllCompilerCalls(
             compilerLogStream,
             options.FilterCompilerCalls);
 
@@ -211,7 +211,7 @@ int RunReferences(IEnumerable<string> args)
 
         using var compilerLogStream = GetOrCreateCompilerLogStream(extra);
         using var reader = CompilerLogReader.Create(compilerLogStream, leaveOpen: true);
-        var compilerCalls = reader.ReadCompilerCalls(options.FilterCompilerCalls);
+        var compilerCalls = reader.ReadAllCompilerCalls(options.FilterCompilerCalls);
 
         baseOutputPath = GetBaseOutputPath(baseOutputPath);
         WriteLine($"Copying references to {baseOutputPath}");
@@ -295,7 +295,7 @@ int RunExport(IEnumerable<string> args)
 
         using var compilerLogStream = GetOrCreateCompilerLogStream(extra);
         using var reader = CompilerLogReader.Create(compilerLogStream, leaveOpen: true);
-        var compilerCalls = reader.ReadCompilerCalls(options.FilterCompilerCalls);
+        var compilerCalls = reader.ReadAllCompilerCalls(options.FilterCompilerCalls);
         var exportUtil = new ExportUtil(reader);
 
         baseOutputPath = GetBaseOutputPath(baseOutputPath);
@@ -404,7 +404,7 @@ int RunDiagnostics(IEnumerable<string> args)
         }
 
         using var compilerLogStream = GetOrCreateCompilerLogStream(extra);
-        var compilationDatas = CompilerLogUtil.ReadCompilationDatas(
+        var compilationDatas = CompilerLogUtil.ReadAllCompilationData(
             compilerLogStream,
             options.FilterCompilerCalls);
 
@@ -463,9 +463,9 @@ List<CompilerCall> GetCompilerCalls(List<string> extra, Func<CompilerCall, bool>
     switch (ext)
     {
         case ".binlog":
-            return BinaryLogUtil.ReadCompilerCalls(stream, new(), predicate);
+            return BinaryLogUtil.ReadAllCompilerCalls(stream, new(), predicate);
         case ".complog":
-            return CompilerLogUtil.ReadCompilerCalls(stream, predicate);
+            return CompilerLogUtil.ReadAllCompilerCalls(stream, predicate);
         default:
             throw new Exception($"Unrecognized file extension: {ext}");
     }

--- a/src/Scratch/Program.cs
+++ b/src/Scratch/Program.cs
@@ -10,9 +10,9 @@ using TraceReloggerLib;
 
 #pragma warning disable 8321
 
-// var filePath = @"c:\users\jaredpar\temp\console\msbuild.binlog";
+var filePath = @"c:\users\jaredpar\temp\console\msbuild.binlog";
 // var filePath = @"C:\Users\jaredpar\code\roslyn\src\Compilers\Core\Portable\msbuild.binlog";
-var filePath = @"C:\Users\jaredpar\Downloads\Roslyn.complog";
+// var filePath = @"C:\Users\jaredpar\Downloads\Roslyn.complog";
 // var filePath = @"C:\Users\jaredpar\code\wt\ros2\artifacts\log\Debug\Build.binlog";
 // var filePath = @"C:\Users\jaredpar\code\roslyn\artifacts\log\Debug\Build.binlog";
 //var filePath = @"C:\Users\jaredpar\code\roslyn\src\Compilers\CSharp\csc\msbuild.binlog";
@@ -23,11 +23,14 @@ var filePath = @"C:\Users\jaredpar\Downloads\Roslyn.complog";
 
 // await SolutionScratchAsync(filePath);
 
+_ = CompilerLogUtil.GetOrCreateCompilerLogStream(filePath);
 
+/*
 var reader = SolutionReader.Create(filePath);
 var info = reader.ReadSolutionInfo();
 var workspace = new AdhocWorkspace();
 workspace.AddSolution(info);
+*/
 
 
 /*
@@ -77,7 +80,7 @@ void RoslynScratch()
     var node = syntaxTree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().Single();
     var cType = context.GetDeclaredSymbol(node);
     var enumerableType = compilation.GetSpecialType(SpecialType.System_Collections_IEnumerable);
-    var conversion = compilation.ClassifyConversion(cType, enumerableType);
+    var conversion = compilation.ClassifyConversion(cType!, enumerableType);
     Console.WriteLine(conversion.Exists);
 
 

--- a/src/Scratch/Program.cs
+++ b/src/Scratch/Program.cs
@@ -60,7 +60,7 @@ foreach (var analyzer in analyzers.AnalyzerReferences)
 }
 */
 
-void RoslynScratch()
+static void RoslynScratch()
 {
     var code = """
         using System.Reflection;
@@ -111,7 +111,7 @@ void ExportTest()
     util.ExportRsp(reader.ReadCompilerCall(0), dest, DotnetUtil.GetSdkDirectories());
 }
 
-void EmptyDirectory(string directory)
+static void EmptyDirectory(string directory)
 {
     if (Directory.Exists(directory))
     {
@@ -121,7 +121,7 @@ void EmptyDirectory(string directory)
     }
 }
 
-void RoundTrip(string binlogFilePath)
+static void RoundTrip(string binlogFilePath)
 {
     var compilerLogFilePath = @"c:\users\jaredpar\temp\compiler.zip";
     using var stream = File.OpenRead(binlogFilePath);
@@ -142,7 +142,7 @@ void RoundTrip(string binlogFilePath)
     }
 }
 
-async Task SolutionScratchAsync(string binlogFilePath)
+static async Task SolutionScratchAsync(string binlogFilePath)
 {
     using var stream = CompilerLogUtil.GetOrCreateCompilerLogStream(binlogFilePath);
     using var reader = SolutionReader.Create(stream, leaveOpen: false);
@@ -160,7 +160,7 @@ async Task SolutionScratchAsync(string binlogFilePath)
     }
 }
 
-void TestDiagnostics(string binlogFilePath)
+static void TestDiagnostics(string binlogFilePath)
 {
     using var compilerLogStream = CompilerLogUtil.GetOrCreateCompilerLogStream(binlogFilePath); 
     using var reader = CompilerLogReader.Create(compilerLogStream);


### PR DESCRIPTION
Changes:
- Move to reading raw records to speed up performance on large binlog files
- Fixed a number of typos
- Cleaned up API names to be more consistent with .NET designs